### PR TITLE
✨ Feat: 스트리밍 기능 백엔드 구현

### DIFF
--- a/chatbot/utils.py
+++ b/chatbot/utils.py
@@ -10,10 +10,16 @@ vector_retriever = VectorRetriever()
 retriever = vector_retriever.get_retriever()
 
 
-def get_chatbot_response(user_message):
+async def get_chatbot_response(user_message):
     """
+    비동기 스트리밍 방식 챗봇 응답을 생성할 수 있는 함수
+
     - 사용자의 입력을 받아 LLM을 실행하고, 단일 응답만 반환 (싱글턴, 대화 기록 저장 X)
     - temperature=0.3: 창의성보다 정확도에 중점을 둠. (추후 조정 가능)
+
+    변동사항 (03/09/25):
+    - async, yield를 사용해 비동기 작업을 할 수 있도록 변경
+    - LLM 응답을 invoke() 방식이 아닌 astream() 비동기 스트리밍 방식으로 변경
     """
 
     # 사용자 질문을 기반으로 문서 검색
@@ -33,7 +39,8 @@ def get_chatbot_response(user_message):
         retrieved_context = "정부의 지원 정책"
 
     # llm 실행 (CHATBOT_PROMPT는 utils1.py에서 import)
-    llm = ChatOpenAI(model_name="gpt-4o-mini", temperature=0.3)
+    # streaming 을 위한 streaming 파라미터 조정
+    llm = ChatOpenAI(model_name="gpt-4o-mini", temperature=0.3, streaming=True)
 
     prompt = CHATBOT_PROMPT
 
@@ -44,9 +51,5 @@ def get_chatbot_response(user_message):
         | StrOutputParser()
     )
 
-    response = rag_chain.invoke(user_message)
-
-    return {
-        "response": response,
-        "retrieved_context": retrieved_context,  # RAG에서 가져온 문서 같이 출력되도록 함(확인용)
-    }
+    async for chunk in rag_chain.astream(user_message):
+        yield chunk


### PR DESCRIPTION
## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
1. 비동기 스트리밍 지원을 위한 챗봇 모델 개선
- 기존의 `get_chatbot_response()` 함수를 async generator로 변경해서 스트리밍 가능하게 변경
- `ChatOpenAI`에 `streaming=True` 파라미터 추가
- `astream()`을 사용하여 순차적인 응답 전송

2. consumers.py에  WebSocket 스트리밍 답변 기능 추가
- 기존의 단일 응답 방식인 `llm_response()` 대신 `async for`루프를 사용해 점진적 스트리밍 방식으로 전환
- `async for`루프는 `get_chatbot_response(user_message)`에서 받은 응답을 chunk 단위로 바로바로 전송
- 전송메시지에 `is_streaming` flag를 추가해 클라이언트가 스트리밍 여부를 확인할 수 있음
- 마지막 응답에 `is_streaming=False`를 추가해 스트리밍이 끝남을 알라고, 마지막 답변도 한번 더 보내서 흘리는 데이터 없도록 함
- docsting 수정함

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
<img width="1030" alt="스크린샷 2025-03-09 오후 2 39 36" src="https://github.com/user-attachments/assets/0fc1afcc-55c2-4a1c-9dbc-f1b200ac7212" />

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->