### PR TITLE
🐛 Fix: Django가 완전히 로드되지 전에 모듈을 불러오는 오류 수정

### DIFF
--- a/config/asgi.py
+++ b/config/asgi.py
@@ -1,12 +1,15 @@
 import os
 
-from channels.routing import ProtocolTypeRouter, URLRouter
-from django.core.asgi import get_asgi_application
+import django  # noqa: E402
 
-from chatbot.middleware import JWTAuthMiddleware
-from chatbot.routing import websocket_urlpatterns
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")  # noqa: E402
+django.setup()  # noqa: E402
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
+from django.core.asgi import get_asgi_application  # noqa: E402
+
+from chatbot.middleware import JWTAuthMiddleware  # noqa: E402
+from chatbot.routing import websocket_urlpatterns  # noqa: E402
 
 application = ProtocolTypeRouter(
     {


### PR DESCRIPTION
## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- `get_asgi_application`를 실행하기 전에 장고가 완전히 로드되지 않은 문제 수정
- `import django` `django.setup()`을 통해 django를 먼저 로드하고 이후 모듈을 로드 할 수 있도록 수정

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->