### PR TITLE
✨ Feat: 소셜이용자 약관동의 받는 로직 구현

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -3,6 +3,7 @@ from rest_framework_simplejwt.views import TokenRefreshView
 
 from .views import (
     ActivateEmailView,
+    AgreeTermsView,
     CurrentStatusListView,
     DeleteAccountView,
     EducationLevelListView,
@@ -54,4 +55,5 @@ urlpatterns = [
         ResetPasswordRenderView.as_view(),
         name="reset_password_render",
     ),
+    path("agree-terms/", AgreeTermsView.as_view(), name="agree_terms"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -382,3 +382,15 @@ class ResetPasswordRenderView(APIView):
                 {"message": "유효하지 않은 토큰입니다."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+
+class AgreeTermsView(APIView):
+    def post(self, request):
+        user = request.user
+        if user.is_authenticated:
+            user.terms_agree = True
+            user.save()
+        return Response(
+            {"message": "수신동의 변경 완료"},
+            status=status.HTTP_200_OK,
+        )

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -208,6 +208,8 @@ class KakaoLoginView(APIView):
         # 4. JWT 발급
         refresh = RefreshToken.for_user(user)
 
+        agree_check = user.is_social and (not user.terms_agree)
+
         return Response(
             {
                 "refresh": str(refresh),
@@ -217,6 +219,7 @@ class KakaoLoginView(APIView):
                     "name": user.name,
                     "is_social": user.is_social,
                     "social_type": user.social_type,
+                    "agree_check": agree_check,
                 },
             },
             status=200,
@@ -261,6 +264,8 @@ class GoogleLoginView(APIView):
         # 4. JWT 발급
         refresh = RefreshToken.for_user(user)
 
+        agree_check = user.is_social and (not user.terms_agree)
+
         return Response(
             {
                 "refresh": str(refresh),
@@ -270,6 +275,7 @@ class GoogleLoginView(APIView):
                     "name": user.name,
                     "is_social": user.is_social,
                     "social_type": user.social_type,
+                    "agree_check": agree_check,
                 },
             },
             status=200,


### PR DESCRIPTION
## 관련 이슈
- 이슈번호(없을 시 생략)

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- 소셜로그인을 진행함
- 백엔드에서 로직처리하고나서 반환값에 하나를 더 보냄
- `is_social` == `True` 이고 `terms_agree` == `False` 이면
- `"agree_check" : True` 라는걸 반환값에 포함
- 프론트에선 `"agree_check" : True` 라면 이용약관 모달을 띄워줌
- 해당 모달에서 동의버튼을 누르면 백엔드에서 `terms_agree` 를 `True` 로 수정

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/efb611ea-6113-4708-9911-069c5cb23f2e)
![social](https://github.com/user-attachments/assets/30f27331-5042-4e73-beab-65abb2b7b899)


## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- 마케팅활용 동의 관련은 미구현
- 이용약관 방식과 동일하게할지 다른방식으로 할지 고려중