### PR TITLE
✨ Feat: 현 모델에서 멀티턴 기능 추가

### DIFF
--- a/chatbot/memory.py
+++ b/chatbot/memory.py
@@ -1,0 +1,60 @@
+import redis
+from django.conf import settings
+from langchain.memory import ConversationSummaryBufferMemory
+from langchain_community.chat_message_histories import RedisChatMessageHistory
+
+
+class ChatHistoryManager:
+    """
+    사용자의 챗봅 대화 기록을 Redis에 저장하고 관리하는 클래스
+
+    Redis를 이용해서 사용자의 대화를 기록 저장하고,
+    LangChain의 `ConversationSummaryBufferMemory`를 통해 200 token 이상의 대화는 요약해서 prompt에 전달해서 사용합니다.
+    대화가 길어져도 성능이나 경제적으로 효율적인 방식으로 과거의 대화 내용을 반영해서 답변을 얻을 수 있게 됩니다.
+
+    주요기능:
+        - Redis를 활용한 사용자별 대화 기록 저장
+        - `ConversationSummaryBufferMemory`를 이용한 대화 요약 및 멀티턴 대화 관리
+        - Redis에 저장된 대화 기록을 삭제하는 기능
+    Args:
+        user_id = 사용자의 id
+        model = 길어진 대화를 요약하는데 사용하는 LLM 모델
+        max_token_limit : 대화 요약을 위한 최대 토큰 제한 (default = 200)
+
+    Methods:
+        get_memory_manager(): 사용자의 대화를 관리할 `ConversationSummaryBufferMemory` 객체 반환
+        clear_history(): 사용자의 대화 기록을 Redis에서 삭제
+    """
+
+    REDIS_DB = 1
+
+    def __init__(self, user_id, model, max_token_limit=200):
+        """ChatHistoryManager 클래스 생성자"""
+        self.user_id = str(user_id)
+        self.model = model
+        self.max_token_limit = max_token_limit
+        self.redis_client = redis.Redis(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            db=self.REDIS_DB,
+            decode_responses=True,
+        )
+
+        self.chat_history = RedisChatMessageHistory(
+            session_id=self.user_id,
+            url=f"redis://{settings.REDIS_HOST}:{settings.REDIS_PORT}/{self.REDIS_DB}",
+        )
+
+    def get_memory_manager(self):
+        """사용자 대화 기록을 관리할 `ConversationSummaryBufferMemory 인스턴스 생성 매서드"""
+        return ConversationSummaryBufferMemory(
+            llm=self.model,
+            chat_memory=self.chat_history,  # Redis에서 관리하는 대화 기록 객체
+            max_token_limit=self.max_token_limit,
+            return_messages=True,  # 전체 대화 메시지 반환 여부
+            memory_key="chat_history",  # 저장된 대화 기록의 key 값
+        )
+
+    def clear_history(self):
+        """Redis에서 대화기록 삭제 매서드"""
+        self.chat_history.clear()

--- a/chatbot/prompt.py
+++ b/chatbot/prompt.py
@@ -4,6 +4,7 @@ from langchain.prompts import (
     ChatPromptTemplate,
     FewShotPromptTemplate,
     HumanMessagePromptTemplate,
+    MessagesPlaceholder,
     PromptTemplate,
     SystemMessagePromptTemplate,
 )
@@ -100,6 +101,7 @@ CHATBOT_PROMPT = ChatPromptTemplate.from_messages(
     [
         system_message,
         HumanMessagePromptTemplate.from_template(few_shot_prompt_text),
+        MessagesPlaceholder(variable_name="chat_history"),
         user_prompt,
     ]
 )

--- a/chatbot/utils.py
+++ b/chatbot/utils.py
@@ -2,6 +2,7 @@ from langchain.schema.runnable import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 from langchain_openai import ChatOpenAI
 
+from .memory import ChatHistoryManager
 from .prompt import CHATBOT_PROMPT
 from .retriever import VectorRetriever
 
@@ -11,16 +12,26 @@ vector_retriever = VectorRetriever()
 retriever = vector_retriever.get_multi_query_retriever()
 
 
-async def get_chatbot_response(user_message):
+async def get_chatbot_response(user_message, user_id):
     """
     비동기 스트리밍 방식 챗봇 응답을 생성할 수 있는 함수
 
-    - 사용자의 입력을 받아 LLM을 실행하고, 단일 응답만 반환 (싱글턴, 대화 기록 저장 X)
+    이 함수는 LangChain의 활용해서 검색 증강 생성(RAG) 방식의 챗봇 응답을 생성합니다.
+    비동기 스트리밍으로 응답으로 실시간으로 반환하고, 대화 기록을 활용해 대화의 흐름을 이어나갈 수 있습니다.
+
+    주요 기능:
+    - 사용자의 입력을 받아 LLM을 실행하고, 비동기 스트리밍 방식으로 응답 바노한
+    - 검색된 문서를 기반으로 하는 답변 제공
+    - `ChatHistoryManager`를 통해 대화 내용을 관리할 수 있음
     - temperature=0.3: 창의성보다 정확도에 중점을 둠. (추후 조정 가능)
+
 
     변동사항 (03/09/25):
     - async, yield를 사용해 비동기 작업을 할 수 있도록 변경
     - LLM 응답을 invoke() 방식이 아닌 astream() 비동기 스트리밍 방식으로 변경
+
+    변동사항 (03/19/25)
+    - `ChatHistoryManager`를 통해 대화 내용 관리 및 멀티턴 기능 추가
     """
 
     # 사용자 질문을 기반으로 문서 검색
@@ -43,14 +54,27 @@ async def get_chatbot_response(user_message):
     # streaming 을 위한 streaming 파라미터 조정
     llm = ChatOpenAI(model_name="gpt-4o-mini", temperature=0.3, streaming=True)
 
+    chat_manager = ChatHistoryManager(user_id, llm)
+    memory_manager = chat_manager.get_memory_manager()
+    memory = memory_manager.load_memory_variables({})
+
     prompt = CHATBOT_PROMPT
 
     rag_chain = (
-        {"context": lambda _: retrieved_context, "question": RunnablePassthrough()}
+        {
+            "context": lambda _: retrieved_context,
+            "question": RunnablePassthrough(),
+            "chat_history": lambda _: memory.get("chat_history", []),
+        }
         | prompt
         | llm
         | StrOutputParser()
     )
 
+    output_response = ""
+
     async for chunk in rag_chain.astream(user_message):
+        output_response += chunk
         yield chunk
+
+    memory_manager.save_context({"human": user_message}, {"ai": output_response})


### PR DESCRIPTION
## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
### 1. Redis와 LangChain을 활용한 멀티턴 대화 기록 관리 memory.py 모듈 추가 
- Redis를 이용해서 사용자별 대화 기록을 저장하는 기능 구현
- LangChain의 `RedisChatMessageHistory`를 활용한 대화 기록 관리
- `ConversationSummaryBufferMemory`를 사용해서 일정 토큰 이상의 대화기록은 요약처리
- 사용자 별 대화 기록을 저장하고 불러올 수 있는 `ChatHistoryManager` 클래스 추가
- 대화기록 삭제 매서드 추가
- Docstring 및 주석 작성

### 2. 대화기록을 위한 MessagesPlaceholder prompy.py에 추가
- 프롬프트에서 이전 대화 기록을 활용할 수 있도록 `MessagesPlaceholder` 추가
- 변수 이름은 `chat_history`로 설정하여 대화 기록을 관리
- `ConversationSummaryBufferMemory`와 함께 사용

### 3. 사용자별 대화 기록을 반영하는 멀티턴 기능 utils.py에 추가
- `user_id`를 이용해 사용자별 대화 히스토리를 관리
- `ChatHistoryManager`를 이용해 대화기록을 관리
- `get_memory_manager()`를 이용해 사용자별 메모리를 불러와, `chat_history`를 체인에 포함하여 멀티턴 구현
- `memory_manager.save_context()`로 사용자 입력과 챗봇 응답을 메모리에 저장

### 4. WebSocket 연결 종료 시 메모리 정리 및 예외 처리 개선
- WebSocket 연결이 종료될 때, `ChatHistoryManager`를 통해 해당 사용자의 대화 기록 정리
- `get_chatbot_response()`의 파라미터 추가로 호출 시 self.user_id를 같이 전달하는 것으로 수정
- 클라이언트에서 보낸 JSON 데이터가 올바르지 않은 형식이거나 파싱 중 오류가 발생할 경우, try-except로 예외 처리

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- Chatroom 기능이 구현되면 user_id와 chatroom_id로 저장하는 로직으로 수정해야 함
- agent를 위한 폴더 구조 변경이 있었지만, 파일이동은 추후에 하겠음 