### PR TITLE
Refactor/news search tool

### DIFF
--- a/chatbot/langchain_flow/prompts/search_prompt.py
+++ b/chatbot/langchain_flow/prompts/search_prompt.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from textwrap import dedent
 from typing import List
 
 from langchain.prompts import ChatPromptTemplate
@@ -19,22 +20,25 @@ def get_news_search_prompt(tools: List[BaseTool]) -> ChatPromptTemplate:
 
     return ChatPromptTemplate.from_messages(
         [
+            ("system", "사용 가능한 도구 목록: {tools_description}"),
             (
                 "system",
-                f"""
-        너는 {current_year}년 기준 최신 정책 정보를 요약해주는 챗봇이야.
-        아래 형식으로 답변을 구성해줘:
+                dedent(
+                    f"""
+                너는 {current_year}년 기준 최신 정책 정보를 요약해주는 챗봇이야.
+                최소 3개 이상의 정보를 알려주고,
+                아래 형식으로 답변을 구성해줘:
 
-        1. 제목:
-        2. 간단 요약:
-        3. 출처 링크:
+                1. 제목:
+                2. 간단 요약:
+                3. 출처 링크:
 
-        뉴스 기사나 공공기관의 공식 사이트만 참고하고, 블로그나 광고성 페이지는 제외해줘.
-        """,
+                뉴스 기사나 공공기관의 공식 사이트만 참고하고, 블로그나 광고성 페이지는 제외해줘.
+            """
+                ),
             ),
             ("placeholder", "{chat_history}"),
             ("user", "{input}"),
             ("system", "{agent_scratchpad}"),
-            ("system", "사용 가능한 도구 목록: {tools_description}"),
         ]
     )

--- a/chatbot/langchain_flow/tools/tavily_news_tool.py
+++ b/chatbot/langchain_flow/tools/tavily_news_tool.py
@@ -1,29 +1,30 @@
 from datetime import datetime
 
-from langchain.tools import Tool
+from langchain.agents import tool
 from langchain_community.tools.tavily_search import TavilySearchResults
 
 current_year = datetime.now().year
 
 
-def search_news_only(query: str) -> str:
+@tool
+def news_search_tool(query: str) -> str:
     """
-    공공 뉴스 도메인에 한정된 Tavily 검색 수행 함수.
+    공공 뉴스 도메인에 한정된 Tavily 검색 수행 툴.
 
     Args:
         query (str): 사용자 검색어
 
     Returns:
         str: Tavily API를 통해 수집된 뉴스 요약 결과
+
+    최신 뉴스 기반 검색을 수행합니다.
+    공공정책 관련 정보를 검색합니다.
+    Tavily API를 이용하며, 신뢰할 수 있는 공식 뉴스 사이트만 대상으로 합니다.
     """
     modified_query = f"{query} site:korea.kr OR site:yna.co.kr OR site:news.kbs.co.kr"
     return TavilySearchResults(k=5)._run(modified_query)
 
 
-news_search_tool = Tool(
-    name="tavily_news_search_tool",
-    func=search_news_only,
-    description=f"""{current_year}년 기준 뉴스 기반 검색을 수행합니다.
-공공정책 관련 정보를 검색합니다.
-Tavily API를 이용하며, 신뢰할 수 있는 공식 뉴스 사이트만 대상으로 합니다.""",
+news_search_tool.__doc__ += (
+    f"\n\n이 툴은 {current_year}년 기준 데이터를 기반으로 검색합니다."
 )


### PR DESCRIPTION
## 관련 이슈
- 해당 사항 없음

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- Tavily 뉴스 검색 툴을 `Tool(...)` 방식에서 `@tool` 데코레이터 방식으로 변경
- docstring에 기반한 자동 설명을 위해 문서 구조 개선 및 현재 연도 정보 추가
- 뉴스 검색 프롬프트에서 도구 목록 (`tools_description`) 위치를 상단으로 이동
- 프롬프트 내 응답 형식을 `textwrap.dedent`를 사용해 가독성 있게 정리

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
- 해당 없음

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- 이 툴은 재활용 가능하도록 설계되어 있습니다.
