### PR TITLE
Refactor/memory delete

### DIFF
--- a/chatbot/consumers.py
+++ b/chatbot/consumers.py
@@ -4,7 +4,6 @@ from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 
 from accounts.models import User
-from chatbot.langchain_flow.memory import ChatHistoryManager
 from chatbot.langchain_flow.run import get_chatbot_response
 from chatbot.models import ChatLog, ChatRoom
 from chatbot.serializers import ChatbotSerializer

--- a/chatbot/consumers.py
+++ b/chatbot/consumers.py
@@ -83,12 +83,6 @@ class ChatConsumer(AsyncWebsocketConsumer):
             )
 
     async def disconnect(self, close_code):
-        if self.is_authenticated:
-            chat_history_manager = ChatHistoryManager(
-                self.user_id, self.room_id, model=None
-            )
-            chat_history_manager.clear_history()
-
         await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
 
     async def receive(self, text_data):

--- a/chatbot/views.py
+++ b/chatbot/views.py
@@ -1,9 +1,10 @@
 from django.http import Http404
 from rest_framework import generics
 
+from chatbot.langchain_flow.memory import ChatHistoryManager
+
 from .models import ChatLog, ChatRoom
 from .serializers import ChatLogSerializer, ChatRoomSerializer
-from chatbot.langchain_flow.memory import ChatHistoryManager
 
 
 class BaseChatRoomView(generics.GenericAPIView):


### PR DESCRIPTION
## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->

- 기존에 챗룸이 구현되기 이전에는 WebSocket 연결이 끊어지면 Redis 메모리를 삭제하는 것을 했었음.
- 기존의 방식과 똑같이 챗룸을 삭제할 때, `ChatHistoryManager`를 이용해 메모리 삭제를 진행함.
- Consumers.py 의 WebSocket이 끊어질 때 삭제로직은 삭제

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->