### PR TITLE
fix/personalized_chatbot

### DIFF
--- a/chatbot/langchain_flow/chains/personalized_rag_chain.py
+++ b/chatbot/langchain_flow/chains/personalized_rag_chain.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables import RunnableMap
+from langchain_openai import ChatOpenAI
+
+from chatbot.langchain_flow.prompts.personalized_rag_prompt import (
+    PERSONALIZED_RAG_PROMPT,
+)
+from chatbot.langchain_flow.tools.detail_rag_tool import detail_rag_tool
+from chatbot.langchain_flow.tools.tavily_web_tool import tavily_web_search_tool
+
+llm = ChatOpenAI(model="gpt-4o", temperature=0.5, streaming=True)
+current_date = datetime.now()
+current_year_month = f"{current_date.year}년 {current_date.month}월"
+
+
+PERSONALIZED_CHAIN = (
+    RunnableMap(
+        {
+            "question": lambda x: x["question"],
+            "context": lambda x: detail_rag_tool.run({"query": " ".join(x["profile"])}),
+            "web_search": lambda x: tavily_web_search_tool.invoke(
+                {
+                    "query": " ".join(x["profile"]),
+                    "k": x.get("k", 4),  # 'k'를 외부 입력에서 받거나 기본값 4
+                }
+            ),
+            "current_year_month": lambda _: current_year_month,
+            "chat_history": lambda x: x.get("chat_history", []),
+        }
+    )
+    | PERSONALIZED_RAG_PROMPT
+    | llm
+    | StrOutputParser()
+)

--- a/chatbot/langchain_flow/classifier.py
+++ b/chatbot/langchain_flow/classifier.py
@@ -19,6 +19,7 @@ class Category(Enum):
     DETAIL_POLICY = "detail_policy"
     REPORT_REQUEST = "report_request"
     SUPPORT_RELATED = "support_related"
+    PERSONALIZED = "personalized"
 
 
 # 각 카테고리에 해당하는 키워드 라스트

--- a/chatbot/langchain_flow/prompt.py
+++ b/chatbot/langchain_flow/prompt.py
@@ -18,8 +18,9 @@ CLASSIFICATION_PROMPT = ChatPromptTemplate.from_messages(
                 - "gov_policy": 정부 또는 지자체의 일반적인 정책, 제도, 지원 유형에 대해 묻는 경우.
                 - "detail_policy": 문장의 주체가 정책, 지원, 또는 정부 서비스와 합리적으로 연결될 수 있으며, 특정 정책이나 지원에 대해 조건, 자격, 신청 절차, 비교, 요구사항 등을 구체적으로 묻는 경우.
                 - "support_related": 재정 지원, 주거, 취업, 사회적 지원 등에 대한 바람이나 필요를 암시하는 간접적이거나 비유적인 표현.
+                - "personalized": 사용자 자신에게 맞는 서비스나 정책을 물어보거나 요청 안내를 하는 경우
 
-            2. 입력이 이전 대화의 후속 질문인지 판단하십시오.
+            2. 입력이 이전 대화의 후속 질문인지 판단하십시오우
                 - 이전 문맥을 기반으로 하거나 이전에 언급된 내용을 참조하는 경우 "is_followup"을 true로 설정하십시오.
                 - 그렇지 않으면 false로 설정하십시오.
 
@@ -28,7 +29,7 @@ CLASSIFICATION_PROMPT = ChatPromptTemplate.from_messages(
                 - 영어로 번역하지 마십시오.
 
             다음과 같은 JSON 형식으로 결과를 반환하십시오:
-                "category": "<category (off_topic | gov_policy | detail_policy | support_related)>",
+                "category": "<category (off_topic | gov_policy | detail_policy | support_related | "personalized")>",
                 "original_input": "<사용자의 원본 입력>",
                 "is_followup": <true | false>,
                 "keywords": <요약 키워드>
@@ -40,6 +41,7 @@ CLASSIFICATION_PROMPT = ChatPromptTemplate.from_messages(
             - "청년 창업 지원금 뭐 있어?" → <"category": "gov_policy", ..., "keywords": "청년을 위한 창업 관련 지원금">
             - "대출 신청 조건은?" → <"category": "detail_policy", ..., "keywords": "대출 신청 조건">
             - "심심하다" → <"category": "off_topic", ..., "keywords": "">
+            - "나한테 맞는 정책이 뭐야?" -> <"category": "personalized", ..., "keywords" "">
             """.strip()
         ),
         MessagesPlaceholder(variable_name="chat_history"),

--- a/chatbot/langchain_flow/prompts/personalized_rag_prompt.py
+++ b/chatbot/langchain_flow/prompts/personalized_rag_prompt.py
@@ -1,0 +1,64 @@
+from langchain.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    MessagesPlaceholder,
+    SystemMessagePromptTemplate,
+)
+
+system_message = SystemMessagePromptTemplate.from_template(
+    """
+    You are an AI assistant specialized in providing accurate and helpful information about government policies and support programs in South Korea.
+    Your role is to assist users by recommending relevant policies, benefits, and procedures in a clear and structured format.
+
+    ## Response Guidelines
+    - Always respond in Korean.
+    - Format your answers using the structure provided below.
+    - Do not guess or hallucinate. When answering the result, include as much relavant information as possible.
+    - Compare the extracted year and month with today’s date: {current_year_month}.
+    - If the latest date in the **기간** field is earlier than {current_year_month}, do not include that policy.
+    - Provide at least 4 recommendations with detail.
+    - If there is a relevant link or source for the policy, include it in the response. Make sure the link is clearly visible and easy to find (e.g., on a separate line or formatted clearly).
+    - **Include a clear and specific reason for recommending each policy in the '추천이유' field.**
+
+    ## Output Format Example
+    Follow the format below **exactly**. Use `:` between each field and its value, and insert proper line breaks between fields.
+
+    입력해주신 소중한 프로필 정보를 바탕으로 추천해드립니다.
+
+    **정책명**: [정책 이름]
+    **대상**: [지원 대상]
+    **지원 내용**: [혜택 및 지원금]
+    **신청 방법**: [절차]
+    **필요 서류**: [필요 서류]
+    **기간**: [신청 가능 기간]
+    **자세히 보기**: [관련 링크]
+    **추천이유**: <추천이유>
+    ---
+
+    """
+)
+# 사용자 메세지
+user_prompt = HumanMessagePromptTemplate.from_template(
+    """
+    ## Reference Documents:
+    {context}
+
+    🔹 위 문서들은 최소 3개 이상의 정보로 구성되어 있습니다.
+    🔹 웹 검색 결과는 1개 이상 포함되며, 없을 경우 생략될 수 있습니다.
+    {web_search}
+
+    ## User Question:
+    {question}
+
+    🔹 Understand the user's intent and context to provide a broad and helpful response.
+    🔹 Based on the provided documents, deliver accurate and relevant information.
+    """
+)
+
+PERSONALIZED_RAG_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        system_message,
+        MessagesPlaceholder(variable_name="chat_history"),
+        user_prompt,
+    ]
+)


### PR DESCRIPTION
## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
FEAT/FIX: 사용자가 프로필을 입력했을 떄, 자신에게 맞는 정책을 추천해달라고 했을 떄, 진행하는 분기 구현
- 분류 카테고리에 personalized 항목 추가
- 분류 LLM에서 맞출형을 요구할 떄, personalized 카테고리로 분류하도록 함
- 카테고리가 personalized 로 분류되었을 때 진행하는 분기 구현
- 사용자 프로필 정보를 사용하는 RAG agent 구현

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->