### PR TITLE
🐛 Fix: 리트리버에서 similarity_search로 인한 score 정렬 실패 수정

### DIFF
--- a/chatbot/retriever.py
+++ b/chatbot/retriever.py
@@ -74,16 +74,14 @@ class VectorRetriever:
         results = []
         for name in collection_names:
             if name not in self.collections:
-                continue  # 등록되지 않은 컬렉션은 스킵
+                continue
             collection = self.collections[name]
-            docs = collection.similarity_search(query, k=k)
-            for doc in docs:
+            docs_with_scores = collection.similarity_search_with_score(query, k=k)
+            for doc, score in docs_with_scores:
                 if self._metadata_match(doc.metadata, filters):
-                    results.append((name, doc))
+                    results.append((name, doc, score))
 
-        return sorted(
-            results, key=lambda x: x[1].metadata.get("score", 0), reverse=True
-        )
+        return sorted(results, key=lambda x: x[2])
 
     def _metadata_match(self, metadata, filters):
         """


### PR DESCRIPTION
## 관련 이슈
fixes #130 

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- `VectorRetriever.search()` 함수에서 `similarity_search()`를 사용해 유사도 점수(score) 없이 정렬하던 문제 해결.  
- `similarity_search_with_score()`로 교체하고, 반환된 score 값을 기준으로 정확하게 오름차순 정렬하도록 수정...


## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
<img width="751" alt="스크린샷 2025-04-09 오후 10 31 02" src="https://github.com/user-attachments/assets/749dda62-a502-4620-b037-498071dbc04b" />

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->