### PR TITLE
🐛 Fix: search 결과 튜플 구조 변경에 따른 format_docs unpack 오류 수정

### DIFF
--- a/chatbot/retriever.py
+++ b/chatbot/retriever.py
@@ -38,10 +38,9 @@ class VectorRetriever:
             dict: 컬렉션 이름을 key로, Chroma 컬렉션 인스턴스를 value로 하는 딕셔너리.
         """
         collection_names = [
-            "gov24_service_list",
-            "gov24_service_detail",
+            "gov24_services",
             "youth_policy_list",
-            "employment_programs",
+            "mongddang_data",
             "pdf_sections",
         ]
         return {
@@ -107,40 +106,40 @@ class VectorRetriever:
         """
         검색된 문서 리스트를 사용자에게 제공할 수 있는 포맷으로 변환.
 
-        - 각 문서에서 제목, 본문 내용, URL을 추출하여 마크다운 형식으로 가공.
-        - URL이 없을 경우 안내 문구로 대체.
+        - 각 문서에서 표준화된 메타데이터(name, region, subject, detail, link)와 본문을 추출하여 마크다운 형식으로 가공.
+        - 링크가 없을 경우 안내 문구로 대체.
+        - score는 내부 정렬용으로만 사용되며 사용자에게 노출되지 않음.
 
         Args:
-            docs (list): [(컬렉션 이름, Document)] 튜플 리스트.
-                        Document는 langchain.schema.Document 객체.
+            docs (list): [(컬렉션 이름, Document, score)] 튜플 리스트.
 
         Returns:
-            str: 문서들의 제목, 내용, URL을 포함한 마크다운 문자열.
-                각 문서는 '\n\n---\n\n' 구분선으로 구분됨.
+            str: 문서들의 제목, 내용, 메타데이터를 포함한 마크다운 문자열.
         """
         formatted = []
-        for name, doc in docs:
+        for name, doc, _ in docs:
             meta = doc.metadata
             content = doc.page_content.strip()
-            title = (
-                meta.get("서비스명")
-                or meta.get("plcyNm")
-                or meta.get("pgmNm")
-                or meta.get("title")
-                or "제목 없음"
-            )
-            link = (
-                meta.get("온라인신청사이트URL")
-                or meta.get("상세조회URL")
-                or meta.get("aplyUrlAddr")
-                or meta.get("refUrlAddr1")
+
+            title = meta.get("name", "제목 없음")
+            region = meta.get("region", "정보 없음")
+            subject = meta.get("subject", "정보 없음")
+            detail = meta.get("detail", "정보 없음")
+            link = meta.get("link")
+
+            link_md = (
+                f"[바로가기]({link})"
+                if link
+                else "해당 서비스는 URL이 제공되지 않습니다."
             )
 
-            if link:
-                link_md = f"[바로가기]({link}) "
-            else:
-                link_md = "해당 서비스는 URL이 제공되지 않습니다. "
-
-            formatted.append(f"**[{title}]**\n- 내용: {content}\n- 링크: {link_md} ")
+            formatted.append(
+                f"**[{title}]**\n"
+                f"- 지역: {region}\n"
+                f"- 지원대상: {subject}\n"
+                f"- 지원내용: {detail}\n"
+                f"- 링크: {link_md}\n"
+                f"- 본문 요약: {content}"
+            )
 
         return "\n\n---\n\n".join(formatted)


### PR DESCRIPTION
## 관련 이슈
- 이슈번호(없을 시 생략)

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- search() 함수가 (컬렉션 이름, Document, score) 형태의 튜플을 반환하도록 변경됨
- format_docs() 함수가 기존 (name, doc) 구조로 unpack하면서 unpack 오류 발생
- score는 사용자 출력에 필요 없으므로 '_'로 무시 처리하여 오류 해결
- 동시에 메타데이터 표준 필드(name, region, subject, detail, link)에 맞춰 포맷 일괄 개선
- 고용24 관련 코드 삭제

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->