### PR TITLE
Feature/fifty plus edu

### DIFF
--- a/dataload/load_data.py
+++ b/dataload/load_data.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 from .common import run_loader
 from .load_employment_data import process_and_store_employment_data
+from .load_fifty_portal_edu_data import process_and_store_fifty_portal_edu_data
 from .load_gov24_data import process_and_store_gov24_data
 from .load_mongddang_data import process_and_store_mongddang_data
 from .load_pdf_data import process_and_store_pdf_data
@@ -61,6 +62,11 @@ def main():
     parser.add_argument(
         "--mongddang", action="store_true", help="몽당정보 데이터 로더 실행"
     )  # 몽땅정보 추가
+    parser.add_argument(
+        "--fifty_portal_edu",
+        action="store_true",
+        help="50플러스포털 교육정보 데이터 로더 실행",
+    )  # 50플러스 교육정보 추가
     parser.add_argument("--all", action="store_true", help="모든 데이터 로더 실행")
     parser.add_argument(
         "--wipe", action="store_true", help="모든 컬렉션 삭제 후 로딩 실행"
@@ -90,6 +96,11 @@ def main():
 
     if args.pdf or args.all:
         run_loader(process_and_store_mongddang_data, "몽땅정보 API")  # 몽땅정보 추가
+
+    if args.fifty or args.all:
+        run_loader(
+            process_and_store_fifty_portal_edu_data, "50플러스포털 교육정보 API"
+        )  # 50플러스 교육정보 추가
 
 
 if __name__ == "__main__":

--- a/dataload/load_fifty_portal_edu_data.py
+++ b/dataload/load_fifty_portal_edu_data.py
@@ -1,0 +1,120 @@
+import os
+import time
+import traceback
+
+import django
+import requests
+from django.conf import settings
+from langchain.schema import Document
+from tqdm import tqdm
+
+from .common import (
+    clear_collection,
+    get_chroma_collection,
+    get_embeddings,
+    prepare_metadata_for_chroma,
+    sanitize_metadata,
+    save_documents_with_progress,
+)
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+SEOUL_API_KEY = settings.SEOUL_API_KEY
+SEOUL_BASE_URL = "http://openapi.seoul.go.kr:8088"
+SERVICE_NAME = "FiftyPotalEduInfo"
+DATA_TYPE = "json"
+PAGE_SIZE = 500
+MAX_PAGES = 4
+API_RATE_LIMIT_DELAY = 1
+
+
+def fetch_fifty_portal_edu_data(start_index, end_index):
+    """
+    서울시 열린데이터 중 50플러스포털 교육정보 API 호출 (최대 3회 재시도)
+    """
+    url = f"{SEOUL_BASE_URL}/{SEOUL_API_KEY}/{DATA_TYPE}/{SERVICE_NAME}/{start_index}/{end_index}"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def parse_fifty_portal_edu_data(json_data):
+    """
+    JSON 데이터에서 지원 사업 항목 리스트 추출
+    """
+    return json_data.get(SERVICE_NAME, {}).get("row", [])
+
+
+def build_fifty_portal_edu_doc(item):
+    """
+    단일 강좌 항목을 Document로 변환
+    """
+    content = f"""
+    강좌명: {item.get('LCT_NM', '정보 없음')}
+    등록 시작일: {item.get('REG_STDE', '정보 없음')}
+    등록 종료일: {item.get('REG_EDDE', '정보 없음')}
+    강좌 시작일: {item.get('CR_STDE', '정보 없음')}
+    강좌 종료일: {item.get('CR_EDDE', '정보 없음')}
+    정원: {item.get('CR_PPL_STAT', '정보 없음')}
+    강좌상태: {item.get('LCT_STAT', '정보 없음')}
+    수강비용: {item.get('LCT_COST', '정보 없음')}
+    상세보기: {item.get('CR_URL', '정보 없음')}
+    """.strip()
+
+    metadata = sanitize_metadata(
+        {
+            "name": item.get("LCT_NM", ""),
+            "link": item.get("CR_URL", ""),
+            "region": "서울시",
+            "source": "50플러스포털",
+        }
+    )
+
+    return Document(page_content=content, metadata=metadata)
+
+
+def process_and_store_fifty_portal_edu_data():
+    """
+    50플러스포털 교육정보 데이터를 수집하고 저장
+    """
+    try:
+        tqdm.write("--- 50플러스포털 교육정보 데이터 로딩 시작 ---")
+        start_time = time.time()
+
+        embeddings = get_embeddings()
+        collection = get_chroma_collection("fifty_portal_edu_data", embeddings)
+        clear_collection(collection, "fifty_portal_edu_data")
+
+        all_docs = []
+
+        # 총 건수를 파악하기 위해 1페이지만 호출해서 list_total_count 확인
+        initial_json = fetch_fifty_portal_edu_data(1, 1)
+        total_count = initial_json.get(SERVICE_NAME, {}).get("list_total_count", 0)
+        total_pages = (total_count + PAGE_SIZE - 1) // PAGE_SIZE
+        tqdm.write(f"총 데이터 수: {total_count}건, 총 페이지 수 {total_pages}페이지")
+
+        for page in tqdm(range(total_pages), desc="데이터 수집 중"):
+            start = page * PAGE_SIZE + 1
+            end = (page + 1) * PAGE_SIZE
+            try:
+                json_data = fetch_fifty_portal_edu_data(start, end)
+                items = parse_fifty_portal_edu_data(json_data)
+                docs = [build_fifty_portal_edu_doc(item) for item in items]
+                all_docs.extend(docs)
+            except Exception as e:
+                tqdm.write(f"[ERROR] 페이지 {page + 1} 수집 실패: {e}")
+            time.sleep(API_RATE_LIMIT_DELAY)
+
+        save_documents_with_progress(collection, prepare_metadata_for_chroma(all_docs))
+
+        elapsed = time.time() - start_time
+        tqdm.write(f"\n총 {len(all_docs)}건 저장 완료. 소요 시간: {elapsed:.2f}초")
+
+    except Exception as e:
+        tqdm.write(f"[ERROR] 데이터 로딩 실패: {e}")
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    process_and_store_fifty_portal_edu_data()

--- a/dataload/tasks.py
+++ b/dataload/tasks.py
@@ -4,6 +4,7 @@ import traceback
 from celery import shared_task
 from tqdm import tqdm
 
+from .load_fifty_portal_edu_data import process_and_store_fifty_portal_edu_data
 from .load_gov24_data import process_and_store_gov24_data
 from .load_mongddang_data import process_and_store_mongddang_data
 from .load_youth_policy_data import process_and_store_youth_policy_data
@@ -44,12 +45,28 @@ def load_youth_policy_data_task():
 @shared_task
 def load_mongddang_data_task():
     """
-    Celery를 통해 실행되는 온통청년 정보 데이터 로딩 작업
+    Celery를 통해 실행되는 몽땅정보 데이터 로딩 작업
     """
     try:
         tqdm.write("=== 몽땅정보 데이터 로딩 시작 (Celery) ===")
         start_time = time.time()
         process_and_store_mongddang_data()
+        elapsed = time.time() - start_time
+        tqdm.write(f"=== 데이터 로딩 완료. 소요 시간: {elapsed:.2f}초 ===")
+    except Exception as e:
+        tqdm.write(f"[ERROR] 데이터 로딩 실패: {e}")
+        traceback.print_exc()
+
+
+@shared_task
+def load_fifty_plus_edu_data_task():
+    """
+    Celery를 통해 실행되는 50플러스포털 교육정보 데이터 로딩 작업
+    """
+    try:
+        tqdm.write("=== 50플러스포털 교육정보 데이터 로딩 시작 (Celery) ===")
+        start_time = time.time()
+        process_and_store_fifty_portal_edu_data()
         elapsed = time.time() - start_time
         tqdm.write(f"=== 데이터 로딩 완료. 소요 시간: {elapsed:.2f}초 ===")
     except Exception as e:


### PR DESCRIPTION
## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
## 1. 서울 열린데이터 '50플러스포털 교육정보' API 데이터 수집 및 벡터 저장
- 서울 열린데이터 광장 API를 활용한 '50플러스포털 교육정보' 데이투 수집 기능 구현
- API 출력값에 있는  list_total_count를 기준으로 전체 페이지 동적 계산하여 처리
- collection_name은 `fifty_portal_edu_data`
- 메타데이터는 name, linke, region, source

## 2. load_data.py 에 50플러스포털 교육정보 데이터 로드 옵션 추가

## 3. 50플러스포털 교육정보 데이터 Celery tasks에 추가

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->